### PR TITLE
DOT-1400 Fix distorted logo on mobile

### DIFF
--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -107,3 +107,12 @@ aside.quote {
 div#topic-title.ember-view {
     padding: 0;
 }
+
+.d-header #site-logo {
+  // Discourse is serving the big logo class even with the mobile view.
+  &.logo-big {
+    height: 3.6em !important;
+    width: auto !important;
+    translate: unset !important;
+  }
+}


### PR DESCRIPTION
Discourse adds a desktop-view/mobile-view class to the top-level HTML node.  The logo still gets served up with the logo-big class - which doesn't feel quite right.  But I can get it to render correctly by editing the theme and adding in some CSS for the mobile view.